### PR TITLE
Add touch api command to ensure it exists and update docker image to use node:18.19-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM busybox:1.35.0-uclibc as busybox
 
 # --------------> The build image
-FROM node:18.11-bullseye AS build
+FROM node:18.19-bullseye AS build
 ARG NPM_TOKEN
 ARG REPO_ORG
 ARG BUILD_NODE_ENV=production

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ runs:
         touch public
         touch private
         touch migrations
+        touch api
         touch next.config.js
         echo "config/development.json" >> .dockerignore
         echo "config/test.json" >> .dockerignore


### PR DESCRIPTION
Just found that I should use this build action to use node v18 for tracker-web as it upgrades node to v18.

Found a small issue during build where docker is running command to copy contents of api folder which is non-existent and fails. Fixing it like how other folders like migrations, public, private etc. are handled.