### PR TITLE
Include static assets in docker image builds for Web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ WORKDIR /pipeline/source
 COPY --chown=nonroot:nonroot --from=build /pipeline/source/node_modules /pipeline/source/node_modules
 COPY --chown=nonroot:nonroot package.json next.config.* coconfig.* /pipeline/source/
 COPY --chown=nonroot:nonroot build/ /pipeline/source/build/
+COPY --chown=nonroot:nonroot build/ /pipeline/source/build-static/
+COPY --chown=nonroot:nonroot build/ /pipeline/source/static/
 COPY --chown=nonroot:nonroot src/ /pipeline/source/src/
 COPY --chown=nonroot:nonroot config/ /pipeline/source/config/
 COPY --chown=nonroot:nonroot migrations/ /pipeline/source/migrations/

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ WORKDIR /pipeline/source
 COPY --chown=nonroot:nonroot --from=build /pipeline/source/node_modules /pipeline/source/node_modules
 COPY --chown=nonroot:nonroot package.json next.config.* coconfig.* /pipeline/source/
 COPY --chown=nonroot:nonroot build/ /pipeline/source/build/
-COPY --chown=nonroot:nonroot build/ /pipeline/source/build-static/
-COPY --chown=nonroot:nonroot build/ /pipeline/source/static/
+COPY --chown=nonroot:nonroot build-static/ /pipeline/source/build-static/
+COPY --chown=nonroot:nonroot static/ /pipeline/source/static/
 COPY --chown=nonroot:nonroot src/ /pipeline/source/src/
 COPY --chown=nonroot:nonroot config/ /pipeline/source/config/
 COPY --chown=nonroot:nonroot migrations/ /pipeline/source/migrations/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Notes
 The Dockerfile copies only selected directories, so you must be careful about where you place files that you want to be in the runtime image. The following directories are copied:
 
 * build - Typically where built code is placed
+* build-static - Typically where resource bundles generated for web pages are placed
+* static - Publicly available files needed for web pages can be placed here such as favicon
 * src - Copied for debuggability, but perhaps should be removed
 * config - Configuration and keys - development.json and test.json will be removed
 * migrations - Database migrations

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,8 @@ runs:
         cp ${{ github.action_path }}/Dockerfile .
         touch public
         touch private
+        touch build-static
+        touch static
         touch migrations
         touch api
         touch next.config.js


### PR DESCRIPTION
This was hard to spot but I just realized after looking at the contents of the staging pod for tracker-web deployment that we're not copying contents of `build-static` folder at all inside the docker image like it is dont with other WEBs.

The reason is that tracker-web uses this Github Action to build production docker image which is quite selectively adding contents needed for docker image, whereas other webs use `https://github.com/gas-buddy/build-push-ecr` to build docker image which just puts all contents inside docker image.

In theory this should fix the tracker-web deployment issue with pod crashing after not finding `build-static/loadable-stats.json`.