### PR TITLE
Use BuildKit secrets for NPM_TOKEN and add node-env input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM public.ecr.aws/docker/library/busybox:1.35.0-uclibc as busybox
 
 # --------------> The build image
 FROM public.ecr.aws/docker/library/node:18.19-bullseye AS build
-ARG NPM_TOKEN
 ARG REPO_ORG
 ARG BUILD_NODE_ENV=production
 WORKDIR /pipeline/source
@@ -31,9 +30,10 @@ RUN ln -sr /staging/busybox /staging/sh && \
 
 # Run our custom yarn setup
 ENV NODE_ENV=$BUILD_NODE_ENV
-RUN yarn config set npmScopes.$REPO_ORG.npmRegistryServer "https://registry.npmjs.org" \
+RUN --mount=type=secret,id=NPM_TOKEN \
+    yarn config set npmScopes.$REPO_ORG.npmRegistryServer "https://registry.npmjs.org" \
     && yarn config set npmScopes.$REPO_ORG.npmAlwaysAuth true \
-    && yarn config set npmScopes.$REPO_ORG.npmAuthToken $NPM_TOKEN \
+    && yarn config set npmScopes.$REPO_ORG.npmAuthToken $(cat /run/secrets/NPM_TOKEN) \
     && yarn plugin import workspace-tools \
     && yarn workspaces focus --production \
     && rm -rf .yarnrc.yml .yarn \
@@ -65,8 +65,9 @@ COPY --chown=nonroot:nonroot private/ /pipeline/source/private/
 
 ## --------------> Flatten where possible
 FROM base
+ARG BUILD_NODE_ENV=production
 USER nonroot
-ENV NODE_ENV production
+ENV NODE_ENV=$BUILD_NODE_ENV
 ENV NODE_NO_WARNINGS 1
 ENV NO_PRETTY_LOGS 1
 ENV PATH /nodejs/bin:$PATH

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,18 @@ inputs:
     description: "The organization to setup for private package installation"
     required: false
     default: gasbuddy
+  node-env:
+    description: "The NODE_ENV value for the Docker build"
+    required: false
+    default: production
 
 runs:
   using: "composite"
   steps:
     - name: Build docker image ${{ inputs.registry-name }}:${{ inputs.image-tag }}
       shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.npm-token }}
       run: |
         cp ${{ github.action_path }}/Dockerfile .
         touch public
@@ -47,7 +53,7 @@ runs:
         touch next.config.js
         echo "config/development.json" >> .dockerignore
         echo "config/test.json" >> .dockerignore
-        docker build --build-arg REPO_ORG=${{ inputs.repo-org }} --build-arg NPM_TOKEN=${{ inputs.npm-token }} -t ${{ inputs.registry-name }}:${{ inputs.image-tag }} .
+        docker build --build-arg REPO_ORG=${{ inputs.repo-org }} --build-arg BUILD_NODE_ENV=${{ inputs.node-env }} --secret id=NPM_TOKEN,env=NPM_TOKEN -t ${{ inputs.registry-name }}:${{ inputs.image-tag }} .
       if: ${{ inputs.skip-build != 'true' }}
 
     - name: Push to ECR


### PR DESCRIPTION
- Replace ARG NPM_TOKEN with --mount=type=secret to prevent token from being stored in image layers (fixes SecretsUsedInArgOrEnv warning)
- Add node-env input to allow customizing NODE_ENV during build
- Redeclare BUILD_NODE_ENV ARG in final stage to properly set NODE_ENV

🤖 Generated with [Claude Code](https://claude.com/claude-code)