### PR TITLE
fix: harden --experimental-global-webcrypto delivery on Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN --mount=type=secret,id=NPM_TOKEN \
     && yarn plugin import workspace-tools \
     && yarn workspaces focus --production \
     && rm -rf .yarnrc.yml .yarn \
-    && echo '#!/bin/sh\n/nodejs/bin/node node_modules/@gasbuddy/service/build/bin/start-service.js --built "$@"' > /staging/start \
-    && echo '#!/bin/sh\n/nodejs/bin/node node_modules/@gasbuddy/service/build/bin/start-service.js --repl "$@"' > /staging/repl \
+    && echo '#!/bin/sh\n/nodejs/bin/node --experimental-global-webcrypto node_modules/@gasbuddy/service/build/bin/start-service.js --built "$@"' > /staging/start \
+    && echo '#!/bin/sh\n/nodejs/bin/node --experimental-global-webcrypto node_modules/@gasbuddy/service/build/bin/start-service.js --repl "$@"' > /staging/repl \
     && chmod a+rx /staging/start /staging/repl \
     && true
 
@@ -61,7 +61,10 @@ RUN groupadd --system --gid 65532 nonroot \
     && mkdir -p /pipeline/source \
     && chown nonroot:nonroot /pipeline/source
 COPY --from=build --chown=nonroot:nonroot /staging/ /bin/
-ENTRYPOINT ["/nodejs/bin/node"]
+ENTRYPOINT ["/nodejs/bin/node", "--experimental-global-webcrypto"]
+
+# Fail the build if the flag does not expose globalThis.crypto (base image regression / multi-arch drift).
+RUN /nodejs/bin/node --experimental-global-webcrypto -e 'if (typeof globalThis.crypto?.getRandomValues !== "function") { console.error("FATAL: --experimental-global-webcrypto did not expose globalThis.crypto"); process.exit(1); }'
 
 ## --------------> Build the pipeline directory
 FROM base as final
@@ -87,11 +90,6 @@ ENV NODE_ENV=$BUILD_NODE_ENV
 ENV NODE_NO_WARNINGS 1
 ENV NO_PRETTY_LOGS 1
 ENV PATH /nodejs/bin:$PATH
-# Enable globalThis.crypto on Node 18. Node 18 only exposes Web Crypto as a global with this
-# flag; bare `crypto` references in module scope (e.g. AWS SDK v3 / @smithy/core v3+ used by
-# @gasbuddy/client-sqs) throw `ReferenceError: crypto is not defined` without it. Node 19+ makes
-# this the default and the flag becomes a no-op, so this is safe to leave in place once consumers
-# move to Node 20.
 ENV NODE_OPTIONS=--experimental-global-webcrypto
 WORKDIR /pipeline/source
 CMD ["node_modules/@gasbuddy/service/build/bin/start-service.js"]


### PR DESCRIPTION
## Summary

Moves `--experimental-global-webcrypto` off the single ENV-var path onto every node invocation argv. Adds a build-time check that fails the docker build if `globalThis.crypto` is not exposed.

## Why

`payment-serv` v23 staging deploy crashed with:

```
ReferenceError: crypto is not defined
    at Object.v4 (/pipeline/source/node_modules/@smithy/core/dist-cjs/submodules/serde/index.js:445:5)
    at async buildEndpoints (/pipeline/source/node_modules/@gasbuddy/client-sqs/build/endpoints.js:51:40)
    at async createSQSClient (/pipeline/source/node_modules/@gasbuddy/client-sqs/build/index.js:21:23)
    at async Object.start (/pipeline/source/build/index.js:83:23)
```

`createSQSClient` -> AWS STS `AssumeRoleWithWebIdentity` (IRSA) -> `@smithy/core` v4 UUID gen uses bare `crypto.getRandomValues()` at module scope. Node 18 needs `--experimental-global-webcrypto` for `globalThis.crypto` to be exposed.

Pre-existing v1.24 already set `ENV NODE_OPTIONS=--experimental-global-webcrypto`, but the flag did not reach the running container (suspected multi-arch manifest drift, EKS pulled platform layer with missing ENV; image manifest is `application/vnd.oci.image.index.v1+json`). Pod CrashLoopBackOff for 30+ minutes, SQS consumers never started, Dwolla NSF/chargeback webhooks unprocessed for hours.

Single-point-of-failure on env-var propagation is fragile. Move the flag to argv where:
- k8s configmap `NODE_OPTIONS` overrides cannot clobber it
- multi-arch build glitches cannot drop it
- consumer Helm charts cannot accidentally clear it

## Changes

1. **ENTRYPOINT** carries the flag: `["/nodejs/bin/node", "--experimental-global-webcrypto"]`
2. **`/bin/start` and `/bin/repl`** shell scripts (used by helm cronjobs and `--repl` paths that bypass ENTRYPOINT) pass the flag inline on argv
3. **Build-time validation**: `RUN node -e '...crypto check...'` fails the docker build if `globalThis.crypto.getRandomValues` is undefined under the flag — catches base image regression / manifest drift at CI build time instead of in production CrashLoopBackOff
4. `ENV NODE_OPTIONS=--experimental-global-webcrypto` kept as belt-and-suspenders for any node invocation that bypasses both ENTRYPOINT and start scripts

## Consumer Impact

**Zero code changes required in consumer repos.** Just bump:

```diff
-uses: gas-buddy/node-docker-build-action@v1.24
+uses: gas-buddy/node-docker-build-action@v1.25
```

Existing helm `NODE_OPTIONS` overrides (e.g. `payment-serv` settleGasback cronjob with `--max-old-space-size=2048 --experimental-global-webcrypto`) keep working. The `--experimental-global-webcrypto` portion becomes redundant (now on argv) and can optionally be dropped in a follow-up cleanup.

## Test plan

- [ ] Local: `docker build -t test .` succeeds, build-time crypto check passes
- [ ] Local: `docker run --rm test --version` works (ENTRYPOINT+flag accept node args)
- [ ] Negative test: temporarily flip the check condition to assert it fails the build correctly
- [ ] Consumer test: bump `@v1.25` in a v23 repo branch, deploy to QA, confirm SQS init succeeds and Dwolla webhooks flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)